### PR TITLE
Provider logo, sorting providers, and showing localized Connect UI page

### DIFF
--- a/Example/Podfile
+++ b/Example/Podfile
@@ -4,6 +4,8 @@ use_frameworks!
 target 'saltedge-ios_Example' do
   pod 'SaltEdge-iOS-Swift', :path => '../'
   pod 'PKHUD', '~> 5.0'
+  pod 'SVGKit', '~> 2.1'
+  pod 'SDWebImageSVGCoder', '~> 0.3'
 
   target 'saltedge-ios_Tests' do
     inherit! :search_paths

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,9 +1,18 @@
 PODS:
+  - CocoaLumberjack (3.5.3):
+    - CocoaLumberjack/Core (= 3.5.3)
+  - CocoaLumberjack/Core (3.5.3)
   - Nimble (7.3.4)
   - PKHUD (5.2.1)
   - Quick (1.3.4)
   - SaltEdge-iOS-Swift (2.1.0):
     - TrustKit
+  - SDWebImage/Core (5.0.3)
+  - SDWebImageSVGCoder (0.3.0):
+    - SDWebImage/Core (~> 5.0)
+    - SVGKit (>= 2.1)
+  - SVGKit (2.1.1):
+    - CocoaLumberjack (~> 3.0)
   - TrustKit (1.6.1)
 
 DEPENDENCIES:
@@ -11,12 +20,18 @@ DEPENDENCIES:
   - PKHUD (~> 5.0)
   - Quick (~> 1.3.2)
   - SaltEdge-iOS-Swift (from `../`)
+  - SDWebImageSVGCoder (~> 0.3)
+  - SVGKit (~> 2.1)
 
 SPEC REPOS:
   https://github.com/cocoapods/specs.git:
+    - CocoaLumberjack
     - Nimble
     - PKHUD
     - Quick
+    - SDWebImage
+    - SDWebImageSVGCoder
+    - SVGKit
     - TrustKit
 
 EXTERNAL SOURCES:
@@ -24,12 +39,16 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
+  CocoaLumberjack: 2f44e60eb91c176d471fdba43b9e3eae6a721947
   Nimble: 051e3d8912d40138fa5591c78594f95fb172af37
   PKHUD: 4e6162c4c39ac367c6934e9855c6b4762ee16256
   Quick: f4f7f063c524394c73ed93ac70983c609805d481
   SaltEdge-iOS-Swift: cdd2402129a7353f10cd82b615a90e8a18f58f80
+  SDWebImage: d4f87d7d36c8a4d9f9459dc282e0caa057fdf935
+  SDWebImageSVGCoder: 4b354bcdc7d74ce14d9fdb3c9ed9ab2c667f3b57
+  SVGKit: 652cdf7bef8bec8564d04a8511d3ab50c7595fac
   TrustKit: 0660dd1ce827ae7c8f553f35502a8542e248188f
 
-PODFILE CHECKSUM: af65592a936e9f7032081206063d1bcd8cde6143
+PODFILE CHECKSUM: 081bd14fb90d2c968a466a27e9a3bc047f9fe132
 
-COCOAPODS: 1.6.1
+COCOAPODS: 1.6.2

--- a/Example/saltedge-ios.xcodeproj/project.pbxproj
+++ b/Example/saltedge-ios.xcodeproj/project.pbxproj
@@ -37,6 +37,8 @@
 		AEEF47A3201B82CE0076CD98 /* StringExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEEF47A2201B82CE0076CD98 /* StringExtensions.swift */; };
 		AEFBA5A02086172700CD09BF /* SEUserDefaultHelperSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEFBA59F2086172700CD09BF /* SEUserDefaultHelperSpec.swift */; };
 		D33E24B0AA9D041B85E197C7 /* Pods_saltedge_ios_Tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 012D5301580879C53F777FDF /* Pods_saltedge_ios_Tests.framework */; };
+		FAC9BA6C22B23E9A00310F6B /* ProviderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9BA6B22B23E9A00310F6B /* ProviderCell.swift */; };
+		FAC9BA6E22B2402200310F6B /* LocaleExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAC9BA6D22B2402200310F6B /* LocaleExtensions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,6 +94,8 @@
 		AEEF47A2201B82CE0076CD98 /* StringExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensions.swift; sourceTree = "<group>"; };
 		AEFBA59F2086172700CD09BF /* SEUserDefaultHelperSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SEUserDefaultHelperSpec.swift; sourceTree = "<group>"; };
 		E2A5E9B41CDB74D9850DC586 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
+		FAC9BA6B22B23E9A00310F6B /* ProviderCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProviderCell.swift; sourceTree = "<group>"; };
+		FAC9BA6D22B2402200310F6B /* LocaleExtensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocaleExtensions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -260,6 +264,7 @@
 			children = (
 				AE299B4220178F440033FCFB /* UserDefaultsHelper.swift */,
 				AEEF47A2201B82CE0076CD98 /* StringExtensions.swift */,
+				FAC9BA6D22B2402200310F6B /* LocaleExtensions.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -268,6 +273,7 @@
 			isa = PBXGroup;
 			children = (
 				AE299B4D2017AD4E0033FCFB /* TransactionTableViewCell.swift */,
+				FAC9BA6B22B23E9A00310F6B /* ProviderCell.swift */,
 			);
 			path = Cells;
 			sourceTree = "<group>";
@@ -404,13 +410,21 @@
 			);
 			inputPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-saltedge-ios_Example/Pods-saltedge-ios_Example-frameworks.sh",
+				"${BUILT_PRODUCTS_DIR}/CocoaLumberjack/CocoaLumberjack.framework",
 				"${BUILT_PRODUCTS_DIR}/PKHUD/PKHUD.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImage/SDWebImage.framework",
+				"${BUILT_PRODUCTS_DIR}/SDWebImageSVGCoder/SDWebImageSVGCoder.framework",
+				"${BUILT_PRODUCTS_DIR}/SVGKit/SVGKit.framework",
 				"${BUILT_PRODUCTS_DIR}/SaltEdge-iOS-Swift/SaltEdge.framework",
 				"${BUILT_PRODUCTS_DIR}/TrustKit/TrustKit.framework",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/CocoaLumberjack.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/PKHUD.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImage.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SDWebImageSVGCoder.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SVGKit.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/SaltEdge.framework",
 				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/TrustKit.framework",
 			);
@@ -483,11 +497,13 @@
 			buildActionMask = 2147483647;
 			files = (
 				AEB851422018E65700127D70 /* AttemptsViewController.swift in Sources */,
+				FAC9BA6E22B2402200310F6B /* LocaleExtensions.swift in Sources */,
 				AE299B4320178F440033FCFB /* UserDefaultsHelper.swift in Sources */,
 				AE9F52CC20164A870057FE09 /* ConnectionsViewController.swift in Sources */,
 				607FACD81AFB9204008FA782 /* ConnectViewController.swift in Sources */,
 				AE31B4BC201B5EC700D00382 /* CredentialTextField.swift in Sources */,
 				AEB851442018E9B200127D70 /* AttemptViewController.swift in Sources */,
+				FAC9BA6C22B23E9A00310F6B /* ProviderCell.swift in Sources */,
 				AE05129D201F3EE1000E5F64 /* OptionsButton.swift in Sources */,
 				AE9F52CF20164E0C0057FE09 /* ProvidersViewController.swift in Sources */,
 				607FACD61AFB9204008FA782 /* AppDelegate.swift in Sources */,

--- a/Example/saltedge-ios/AppDelegate.swift
+++ b/Example/saltedge-ios/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let appId: String = "your-app-id"
         let appSecret: String = "your-app-secret"
         let customerId: String = "customer-secret"
-
+        
         // By default SSL Pinning is enabled, to disable it use:
         // SERequestManager.shared.set(sslPinningEnabled: false)
 

--- a/Example/saltedge-ios/AppDelegate.swift
+++ b/Example/saltedge-ios/AppDelegate.swift
@@ -49,7 +49,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let appId: String = "your-app-id"
         let appSecret: String = "your-app-secret"
         let customerId: String = "customer-secret"
-        
+
         // By default SSL Pinning is enabled, to disable it use:
         // SERequestManager.shared.set(sslPinningEnabled: false)
 

--- a/Example/saltedge-ios/Base.lproj/Main.storyboard
+++ b/Example/saltedge-ios/Base.lproj/Main.storyboard
@@ -353,6 +353,44 @@
                             <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="28" sectionFooterHeight="28" translatesAutoresizingMaskIntoConstraints="NO" id="kLM-pM-iaC">
                                 <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <prototypes>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" selectionStyle="blue" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="ProviderCell" id="ICU-85-Kag" customClass="ProviderCell" customModule="saltedge_ios_Example" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="28" width="375" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="ICU-85-Kag" id="457-WE-J6i">
+                                            <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bqy-4k-iQd">
+                                                    <rect key="frame" x="51.5" y="0.0" width="307.5" height="43.5"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8Vr-oW-ISN" customClass="SVGKFastImageView">
+                                                    <rect key="frame" x="0.0" y="0.0" width="43.5" height="43.5"/>
+                                                    <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" secondItem="8Vr-oW-ISN" secondAttribute="height" multiplier="1:1" id="iVV-C2-I50"/>
+                                                    </constraints>
+                                                </view>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="8Vr-oW-ISN" firstAttribute="top" secondItem="457-WE-J6i" secondAttribute="top" id="8Ju-HN-Z6M"/>
+                                                <constraint firstAttribute="trailing" secondItem="bqy-4k-iQd" secondAttribute="trailing" constant="16" id="P5H-3V-weQ"/>
+                                                <constraint firstAttribute="bottom" secondItem="8Vr-oW-ISN" secondAttribute="bottom" id="SJp-vi-KNM"/>
+                                                <constraint firstItem="bqy-4k-iQd" firstAttribute="top" secondItem="457-WE-J6i" secondAttribute="top" id="ald-1c-FBI"/>
+                                                <constraint firstItem="bqy-4k-iQd" firstAttribute="leading" secondItem="8Vr-oW-ISN" secondAttribute="trailing" constant="8" id="gLS-Hu-yTQ"/>
+                                                <constraint firstItem="8Vr-oW-ISN" firstAttribute="leading" secondItem="457-WE-J6i" secondAttribute="leading" id="gVR-l9-kp6"/>
+                                                <constraint firstAttribute="bottom" secondItem="bqy-4k-iQd" secondAttribute="bottom" id="gwt-5I-gvt"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <outlet property="logoImageView" destination="8Vr-oW-ISN" id="ASl-Gu-Ygg"/>
+                                            <outlet property="titleLabel" destination="bqy-4k-iQd" id="8Ce-5W-M90"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </prototypes>
                             </tableView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>

--- a/Example/saltedge-ios/Components/Cells/ProviderCell.swift
+++ b/Example/saltedge-ios/Components/Cells/ProviderCell.swift
@@ -23,7 +23,6 @@ class ProviderCell : UITableViewCell {
     
     private func updateUI() {
         titleLabel.text = provider?.name
-//        logoImageView.sd_adjustContentMode = true // make `contentMode` works
         logoImageView.sd_setImage(with: provider?.logoURL, completed: nil)
     }
 }

--- a/Example/saltedge-ios/Components/Cells/ProviderCell.swift
+++ b/Example/saltedge-ios/Components/Cells/ProviderCell.swift
@@ -1,0 +1,29 @@
+//
+//  ProviderCell.swift
+//  saltedge-ios_Example
+//
+//  Created by Alexander Petropavlovsky on 13/06/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import UIKit
+import SVGKit
+import SaltEdge
+import SDWebImageSVGCoder
+
+class ProviderCell : UITableViewCell {
+    @IBOutlet weak var titleLabel: UILabel!
+    @IBOutlet weak var logoImageView: SVGKFastImageView!
+    
+    var provider: SEProvider? = nil {
+        didSet {
+            updateUI()
+        }
+    }
+    
+    private func updateUI() {
+        titleLabel.text = provider?.name
+//        logoImageView.sd_adjustContentMode = true // make `contentMode` works
+        logoImageView.sd_setImage(with: provider?.logoURL, completed: nil)
+    }
+}

--- a/Example/saltedge-ios/Utils/LocaleExtensions.swift
+++ b/Example/saltedge-ios/Utils/LocaleExtensions.swift
@@ -1,0 +1,15 @@
+//
+//  LocaleExtensions.swift
+//  saltedge-ios_Example
+//
+//  Created by Alexander Petropavlovsky on 13/06/2019.
+//  Copyright © 2019 CocoaPods. All rights reserved.
+//
+
+import Foundation
+
+extension Locale {
+    static var preferredLanguageCode: String {
+        return String(Locale.preferredLanguages[0].prefix(2))
+    }
+}

--- a/Example/saltedge-ios/View Controllers/ConnectViewController.swift
+++ b/Example/saltedge-ios/View Controllers/ConnectViewController.swift
@@ -66,8 +66,9 @@ final class ConnectViewController: UIViewController {
             
             // Set javascriptCallbackType to "iframe" to receive callback with connection_id and connection_secret
             // see https://docs.saltedge.com/guides/connect
+            let languageCode = Locale.preferredLanguageCode.lowercased()
             let connectSessionsParams = SECreateSessionsParams(
-                attempt: SEAttempt(returnTo: "http://httpbin.org"),
+                attempt: SEAttempt(locale: languageCode, returnTo: "http://httpbin.org"),
                 providerCode: provider.code,
                 javascriptCallbackType: "iframe",
                 consent: SEConsent(scopes: ["account_details", "transactions_details"])

--- a/saltedge-ios-swift/Classes/API/Models/Responses/SEProvider.swift
+++ b/saltedge-ios-swift/Classes/API/Models/Responses/SEProvider.swift
@@ -41,6 +41,7 @@ public struct SEProvider: Decodable {
     public let createdAt: String
     public let updatedAt: String
     public let requiredFields: [SEProviderField]?
+    public let logoURL: URL
     
     public var isOAuth: Bool {
         return mode == "oauth"
@@ -64,6 +65,7 @@ public struct SEProvider: Decodable {
         case createdAt = "created_at"
         case updatedAt = "updated_at"
         case requiredFields = "required_fields"
+        case logoURL = "logo_url"
     }
 }
 


### PR DESCRIPTION
Hello guys. 

I've made some changes in the lib and example project, hope they will be helpful.

- Added `logoURL` attribute into `SEProvider` model
- Displayed logos in providers list (I had to add `SVGKit` and `SDWebImageSVGCoder` pods because logos are in SVG format)
- Sorted providers by country, and placed providers from current country at the top of the list
- Included `locale` into `SEAttempt` of `SECreateSessionsParams` payload, so that the Connect UI page returned localized