### PR TITLE
Make lead session parameters inheritable by consuming applications

### DIFF
--- a/saltedge-ios-swift/Classes/API/Models/Parameters/SELeadSessionParams.swift
+++ b/saltedge-ios-swift/Classes/API/Models/Parameters/SELeadSessionParams.swift
@@ -24,11 +24,13 @@
 import Foundation
 
 open class SELeadSessionParams: SEConnectSessionsParams {
+    public let customerId: String?
     public let categorization: String?
     public let returnConnectionSearch: Bool?
     public let skipProviderSelect: Bool?
 
     public init(consent: SEConsent,
+                customerId: String? = nil,
                 allowedCountries: [String]? = nil,
                 credentialsStrategy: String? = nil,
                 providerCode: String? = nil,
@@ -48,6 +50,7 @@ open class SELeadSessionParams: SEConnectSessionsParams {
                 includeFakeProviders: Bool? = nil,
                 lostConnectionNotify: Bool? = nil,
                 showConsentConfirmation: Bool? = nil) {
+        self.customerId = customerId
         self.categorization = categorization
         self.returnConnectionSearch = returnConnectionSearch
         self.skipProviderSelect = skipProviderSelect
@@ -68,6 +71,7 @@ open class SELeadSessionParams: SEConnectSessionsParams {
     }
 
     private enum CodingKeys: String, CodingKey {
+        case customerId = "customer_id"
         case categorization = "categorization"
         case returnConnectionSearch = "return_connection_search"
         case skipProviderSelect = "skip_provider_select"
@@ -75,6 +79,7 @@ open class SELeadSessionParams: SEConnectSessionsParams {
 
     open override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(customerId, forKey: .customerId)
         try container.encodeIfPresent(categorization, forKey: .categorization)
         try container.encodeIfPresent(returnConnectionSearch, forKey: .returnConnectionSearch)
         try container.encodeIfPresent(skipProviderSelect, forKey: .skipProviderSelect)

--- a/saltedge-ios-swift/Classes/API/Models/Parameters/SELeadSessionParams.swift
+++ b/saltedge-ios-swift/Classes/API/Models/Parameters/SELeadSessionParams.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-public class SELeadSessionParams: SEConnectSessionsParams {
+open class SELeadSessionParams: SEConnectSessionsParams {
     public let categorization: String?
     public let returnConnectionSearch: Bool?
     public let skipProviderSelect: Bool?
@@ -73,7 +73,7 @@ public class SELeadSessionParams: SEConnectSessionsParams {
         case skipProviderSelect = "skip_provider_select"
     }
 
-    public override func encode(to encoder: Encoder) throws {
+    open override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encodeIfPresent(categorization, forKey: .categorization)
         try container.encodeIfPresent(returnConnectionSearch, forKey: .returnConnectionSearch)

--- a/saltedge-ios-swift/Classes/API/Models/Parameters/SESessionsParams.swift
+++ b/saltedge-ios-swift/Classes/API/Models/Parameters/SESessionsParams.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-public class SEBaseSessionsParams: Encodable, ParametersEncodable {
+open class SEBaseSessionsParams: Encodable, ParametersEncodable {
     public let customFields: String?
     public let dailyRefresh: Bool?
     public let disableProviderSearch: Bool?
@@ -83,7 +83,7 @@ public class SEBaseSessionsParams: Encodable, ParametersEncodable {
     }
 }
 
-public class SEConnectSessionsParams: SEBaseSessionsParams {
+open class SEConnectSessionsParams: SEBaseSessionsParams {
     public let consent: SEConsent
     public let allowedCountries: [String]?
     public let credentialsStrategy: String?


### PR DESCRIPTION
Update SELeadSessionParam and ancestors from public to open so that consuming applications can inherit to enhance functionality.