### PR TITLE
[3.3.14] Fixed SEBaseConsentsParams to be url encodable. Updated pods in example project.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.14] - 2021-07-19
+
+### Fixed.
+
+- Fixed `SEBaseConsentsParams` to be url encodable
+
 ## [3.3.13] - 2021-03-17
 
 ### Fixed.

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - Nimble (9.2.0)
   - PKHUD (5.3.0)
   - Quick (4.0.0)
-  - SaltEdge-iOS-Swift (3.3.13):
+  - SaltEdge-iOS-Swift (3.3.14):
     - TrustKit
   - SDWebImage (5.11.1):
     - SDWebImage/Core (= 5.11.1)
@@ -45,7 +45,7 @@ SPEC CHECKSUMS:
   Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
   Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
-  SaltEdge-iOS-Swift: ea920ac5e3b3e7e9d6fe9658abaca713068a2526
+  SaltEdge-iOS-Swift: e72449fc25456a70339059043080df16a2bf31c0
   SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
   SDWebImageSVGKitPlugin: 8797e1c9b9baf80bd50d28e673e16a12359af1c9
   SVGKit: 1ad7513f8c74d9652f94ed64ddecda1a23864dea

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,19 +1,19 @@
 PODS:
-  - CocoaLumberjack (3.7.0):
-    - CocoaLumberjack/Core (= 3.7.0)
-  - CocoaLumberjack/Core (3.7.0)
-  - Nimble (9.0.0)
+  - CocoaLumberjack (3.7.2):
+    - CocoaLumberjack/Core (= 3.7.2)
+  - CocoaLumberjack/Core (3.7.2)
+  - Nimble (9.2.0)
   - PKHUD (5.3.0)
-  - Quick (3.0.0)
+  - Quick (4.0.0)
   - SaltEdge-iOS-Swift (3.3.13):
     - TrustKit
-  - SDWebImage (5.9.2):
-    - SDWebImage/Core (= 5.9.2)
-  - SDWebImage/Core (5.9.2)
-  - SDWebImageSVGKitPlugin (1.2.0):
-    - SDWebImage/Core (~> 5.6)
+  - SDWebImage (5.11.1):
+    - SDWebImage/Core (= 5.11.1)
+  - SDWebImage/Core (5.11.1)
+  - SDWebImageSVGKitPlugin (1.3.0):
+    - SDWebImage/Core (~> 5.10)
     - SVGKit (>= 2.1)
-  - SVGKit (2.1.1):
+  - SVGKit (3.0.0):
     - CocoaLumberjack (~> 3.0)
   - TrustKit (1.6.5)
 
@@ -41,14 +41,14 @@ EXTERNAL SOURCES:
     :path: "../"
 
 SPEC CHECKSUMS:
-  CocoaLumberjack: e8955b9d337ac307103b0a34fd141c32f27e53c5
-  Nimble: 3b4ec3fd40f1dc178058e0981107721c615643d8
+  CocoaLumberjack: b7e05132ff94f6ae4dfa9d5bce9141893a21d9da
+  Nimble: 4f4a345c80b503b3ea13606a4f98405974ee4d0b
   PKHUD: 98f3e4bc904b9c916f1c5bb6d765365b5357291b
-  Quick: 6d9559f40647bc4d510103842ef2fdd882d753e2
+  Quick: 6473349e43b9271a8d43839d9ba1c442ed1b7ac4
   SaltEdge-iOS-Swift: ea920ac5e3b3e7e9d6fe9658abaca713068a2526
-  SDWebImage: 0b42b8719ab0c5257177d5894306e8a336b21cbb
-  SDWebImageSVGKitPlugin: 06a811c05b9e839982baeb5251d15fe7a79abb82
-  SVGKit: 652cdf7bef8bec8564d04a8511d3ab50c7595fac
+  SDWebImage: a7f831e1a65eb5e285e3fb046a23fcfbf08e696d
+  SDWebImageSVGKitPlugin: 8797e1c9b9baf80bd50d28e673e16a12359af1c9
+  SVGKit: 1ad7513f8c74d9652f94ed64ddecda1a23864dea
   TrustKit: 073855e3adecd317417bda4ac9e9ac54a2e3b9f2
 
 PODFILE CHECKSUM: 571d1eb7bfecd2002bb7e1babcc966a9bccbf0a4

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Last SDK version (3+) supports Salt Edge API v5.
 for Salt Edge API v5 use
 
 ```ruby
-pod 'SaltEdge-iOS-Swift', '~> 3.3.13'
+pod 'SaltEdge-iOS-Swift', '~> 3.3.14'
 ```
 
 for Salt Edge API v4 (***Deprecated***) use 
@@ -242,7 +242,7 @@ Set up the `appId`,  `appSecret` and `customerId` constants to your App ID and c
 
 ## Versioning
 
-The current version of the SDK is [3.3.13](https://github.com/saltedge/saltedge-ios-swift/releases/tag/3.3.13), and supports the latest available version of Salt Edge API. Any backward-incompatible changes in the API will result in changes to the SDK.
+The current version of the SDK is [3.3.13](https://github.com/saltedge/saltedge-ios-swift/releases/tag/3.3.14), and supports the latest available version of Salt Edge API. Any backward-incompatible changes in the API will result in changes to the SDK.
 
 ## Security
 

--- a/SaltEdge-iOS-Swift.podspec
+++ b/SaltEdge-iOS-Swift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SaltEdge-iOS-Swift'
-  s.version          = '3.3.13'
+  s.version          = '3.3.14'
   s.summary          = "A handful of classes to help you interact with the Salt Edge API from your iOS or macOS app."
   s.description      = <<-DESC
                    SaltEdge-iOS is a library targeted at easing the interaction with the [Salt Edge API](https://docs.saltedge.com/).

--- a/saltedge-ios-swift/Classes/API/Models/Parameters/SEConsentsParams.swift
+++ b/saltedge-ios-swift/Classes/API/Models/Parameters/SEConsentsParams.swift
@@ -24,7 +24,7 @@
 
 import Foundation
 
-public class SEBaseConsentsParams: Encodable, ParametersEncodable {
+public class SEBaseConsentsParams: URLEncodable, ParametersEncodable {
     public let id: String?
     public let connectionId: String?
     public let customerId: String?


### PR DESCRIPTION
https://github.com/saltedge/saltedge-ios-swift/issues/67