### PR TITLE
Add Swift Package Manager compatibility and call completion block as soon as createConnection succeeds

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
    targets: [
        .target(
            name: "SaltEdge",
-           path: "SaltEdge"
+           path: "saltedge-ios-swift/Classes"
        )
    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,1 +1,16 @@
-.package(url: "https://github.com/Dobin-Pte-Ltd/saltedge-ios-swift.git", .branch("master"))
+// swift-tools-version:5.6
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+import PackageDescription
+
+let package = Package(
+    name: "Saltedge-iOS-Swift",
+    products: [
+       .library(name: "SaltEdge", targets: ["SaltEdge"])
+   ],
+   targets: [
+       .target(
+           name: "SaltEdge",
+           path: "SaltEdge"
+       )
+   ]
+)

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,1 @@
+.package(url: "https://github.com/Dobin-Pte-Ltd/saltedge-ios-swift.git", .branch("master"))

--- a/saltedge-ios-swift/Classes/API/SEConnectionFetcher.swift
+++ b/saltedge-ios-swift/Classes/API/SEConnectionFetcher.swift
@@ -130,6 +130,7 @@ class SEConnectionFetcher {
     
     private static func handleSuccessPollResponse(for connection: SEConnection, fetchingDelegate: SEConnectionFetchingDelegate) {
         switch connection.stage {
+            
         case "interactive":
             fetchingDelegate.interactiveInputRequested(for: connection)
         case "finish":
@@ -139,6 +140,7 @@ class SEConnectionFetcher {
                 fetchingDelegate.successfullyFinishedFetching(connection: connection)
             }
         default:
+            fetchingDelegate.connectionStageDidChange(connection)
             self.requestPolling(for: connection, fetchingDelegate: fetchingDelegate)
         }
     }

--- a/saltedge-ios-swift/Classes/API/SEConnectionFetcher.swift
+++ b/saltedge-ios-swift/Classes/API/SEConnectionFetcher.swift
@@ -34,6 +34,7 @@ class SEConnectionFetcher {
         HTTPService<SEConnection>.makeRequest(ConnectionRouter.create(params)) { response in
             switch response {
             case .success(let value):
+                completion?(.success(value))
                 self.requestPolling(for: value.data, fetchingDelegate: fetchingDelegate)
             case .failure(let error):
                 completion?(.failure(error))

--- a/saltedge-ios-swift/Classes/API/SEConnectionFetchingDelegate.swift
+++ b/saltedge-ios-swift/Classes/API/SEConnectionFetchingDelegate.swift
@@ -50,4 +50,9 @@ public protocol SEConnectionFetchingDelegate: class {
      - parameter connection: The connection which was successfully connected and finished fetching.
      */
     func successfullyFinishedFetching(connection: SEConnection)
+    
+    /**
+     Sent to delegate when the intermediate conneciton stage changes (not error, success or interactive)
+     */
+    func connectionStageDidChange(_ connection: SEConnection)
 }


### PR DESCRIPTION
A lot of developers have moved away from Cocoa Pods with the new Swift Package Manager. I have added the required Package.swift file so that the Saltedge SDK can also be integrated via SPM (Cocoa pod is still an option of course).

I have also added a call to the completion block in createConnection upon success. This would allow app to get information about the newly created connection (connection ID for example) as soon as it is created rather than waiting for the interactive or finish delegate calls.